### PR TITLE
CI: Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,20 +8,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
-        fluentd: ['1.11.5', '1.12.2']
-    name: Ruby ${{ matrix.ruby }} Fluentd ${{ matrix.fluentd }}
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+    name: Ruby ${{ matrix.ruby }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Run the default task
       run: |
-        gem install fluentd -v ${{ matrix.fluentd }}
-        gem install rake -v 12.0
-        gem install webrick
         rake build
         gem install ./pkg/fluent-plugin-utmpx*.gem
         TESTOPTS="--verbose" bundle exec rake

--- a/fluent-plugin-utmpx.gemspec
+++ b/fluent-plugin-utmpx.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "linux-utmpx", "~> 0.3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 
-  spec.add_development_dependency "bundler", "~> 2.2.15"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.5"
   spec.add_development_dependency "webrick"
 end


### PR DESCRIPTION
Update Ruby and Fluentd versions and so on.

I fixed to run the tests on the latest Fluentd, but should we add some Fluentd versions as before?
If so, I will fix it.

And, should we create a gem test instead of the following steps?
(Like https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/blob/master/.github/workflows/test.yml)

```
        rake build
        gem install ./pkg/fluent-plugin-utmpx*.gem
```

If so, I will make the PR following this.
