### PR TITLE
Fix dependency to Fluentd v1.14.0 or later

### DIFF
--- a/fluent-plugin-utmpx.gemspec
+++ b/fluent-plugin-utmpx.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "linux-utmpx", "~> 0.3.0"
-  spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
+  spec.add_runtime_dependency "fluentd", [">= 1.14.0", "< 2"]
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
After merged PR#8, that PR require changes which
is introduced in v1.14.0.

gemspec must be resolved to v1.14.0 or later.